### PR TITLE
fix: add explicit permissions to deploy job for workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,9 @@ jobs:
 
   # Deployment job
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The deploy job needs explicit `id-token: write` permission for OIDC-based GitHub Pages deployments. While this permission is set at the workflow level, it must also be explicitly set at the job level for the deployment to work when triggered via workflow_dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)